### PR TITLE
Replacing "Macro" to "GoSub"

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -164,7 +164,7 @@ exten => s,n(no),Verbose(Exit record);
 
 ```
 [internal]
-exten => _X.,1,Macro(recording,${CALLERID(num)},${EXTEN})
+exten => _X.,1,GoSub(recording,s,1(${CALLERID(num)},${EXTEN}))
 exten => _X.,n,Dial(SIP/${EXTEN},60)
 exten => _X.,n,Hangup()
 ```


### PR DESCRIPTION
App_macro is deprecated[1] and not exists[2] in default build of Asterisk.
GoSub is suitable function.

[1] Details: https://wiki.asterisk.org/wiki/display/AST/app_macro+Deprecation
[2] Can cause this error: pbx.c:2907 pbx_extension_helper: No application 'Macro' for extension (context,,)

